### PR TITLE
Add login modal and logout option

### DIFF
--- a/src/RequireAuth.tsx
+++ b/src/RequireAuth.tsx
@@ -1,21 +1,25 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useAuth } from './AuthContext'
+import LoginModal from './components/LoginModal'
 
 const RequireAuth: React.FC<{ children: JSX.Element }> = ({ children }) => {
-  const { user, loading, signIn } = useAuth()
+  const { user, loading } = useAuth()
+  const [showModal, setShowModal] = useState(false)
+
+  useEffect(() => {
+    if (!loading && !user) {
+      setShowModal(true)
+    } else {
+      setShowModal(false)
+    }
+  }, [loading, user])
 
   if (loading) {
     return <div className="p-8 text-center">Chargement...</div>
   }
 
   if (!user) {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <button onClick={signIn} className="magic-button bg-tomato-500 text-white px-4 py-2 rounded-xl">
-          Se connecter avec Google
-        </button>
-      </div>
-    )
+    return showModal ? <LoginModal onClose={() => setShowModal(false)} /> : null
   }
 
   return children

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,13 @@
 import React, { useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { Menu, X, Sparkles } from 'lucide-react'
+import { useAuth } from '../AuthContext'
+import LoginModal from './LoginModal'
 
 const Header: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const [showLogin, setShowLogin] = useState(false)
+  const { user, signOutUser } = useAuth()
   const location = useLocation()
 
   const navigation = [
@@ -32,7 +36,7 @@ const Header: React.FC = () => {
           </Link>
 
           {/* Desktop Navigation */}
-          <nav className="hidden md:flex space-x-8">
+          <nav className="hidden md:flex space-x-8 items-center">
             {navigation.map((item) => (
               <Link
                 key={item.name}
@@ -46,6 +50,21 @@ const Header: React.FC = () => {
                 {item.name}
               </Link>
             ))}
+            {user ? (
+              <button
+                onClick={signOutUser}
+                className="px-3 py-2 rounded-lg text-sm font-medium text-gray-700 hover:text-tomato-600"
+              >
+                Déconnexion
+              </button>
+            ) : (
+              <button
+                onClick={() => setShowLogin(true)}
+                className="px-3 py-2 rounded-lg text-sm font-medium text-gray-700 hover:text-tomato-600"
+              >
+                Connexion
+              </button>
+            )}
           </nav>
 
           {/* Mobile menu button */}
@@ -77,9 +96,31 @@ const Header: React.FC = () => {
                   {item.name}
                 </Link>
               ))}
+              {user ? (
+                <button
+                  onClick={() => {
+                    signOutUser()
+                    setIsMenuOpen(false)
+                  }}
+                  className="text-left px-3 py-2 rounded-lg text-sm font-medium text-gray-700 hover:text-tomato-600"
+                >
+                  Déconnexion
+                </button>
+              ) : (
+                <button
+                  onClick={() => {
+                    setIsMenuOpen(false)
+                    setShowLogin(true)
+                  }}
+                  className="text-left px-3 py-2 rounded-lg text-sm font-medium text-gray-700 hover:text-tomato-600"
+                >
+                  Connexion
+                </button>
+              )}
             </nav>
           </div>
         )}
+        {showLogin && <LoginModal onClose={() => setShowLogin(false)} />}
       </div>
     </header>
   )

--- a/src/components/LoginModal.tsx
+++ b/src/components/LoginModal.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { X } from 'lucide-react'
+import { useAuth } from '../AuthContext'
+
+interface LoginModalProps {
+  onClose: () => void
+}
+
+const LoginModal: React.FC<LoginModalProps> = ({ onClose }) => {
+  const { signIn } = useAuth()
+
+  const handleLogin = async () => {
+    await signIn()
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="glass-card p-6 rounded-3xl max-w-sm w-full relative">
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-2 text-gray-500 hover:text-gray-700"
+        >
+          <X className="h-5 w-5" />
+        </button>
+        <h2 className="text-xl font-bold text-gray-800 mb-4 text-center">Se connecter</h2>
+        <div className="text-center">
+          <button
+            onClick={handleLogin}
+            className="magic-button bg-tomato-500 text-white px-4 py-2 rounded-xl"
+          >
+            Connexion Google
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default LoginModal


### PR DESCRIPTION
## Summary
- implement a reusable `LoginModal` component
- display login modal when visiting protected pages
- add login/logout controls in the header

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845abcdc6f88326a8a3345f8f96a3ad