### PR TITLE
Add Firestore user profiles

### DIFF
--- a/src/AuthContext.tsx
+++ b/src/AuthContext.tsx
@@ -1,12 +1,16 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 import { User, onAuthStateChanged, signInWithPopup, signOut, GoogleAuthProvider } from 'firebase/auth'
-import { auth, provider } from './firebase'
+import { doc, getDoc, setDoc } from 'firebase/firestore'
+import { auth, provider, db } from './firebase'
+import CompleteProfileModal from './components/CompleteProfileModal'
 
 interface AuthContextType {
   user: User | null
   loading: boolean
   signIn: () => Promise<void>
   signOutUser: () => Promise<void>
+  profileNeedsCompletion: boolean
+  saveProfile: (data: { firstName: string; lastName: string; age: number }) => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextType>({} as AuthContextType)
@@ -14,6 +18,7 @@ const AuthContext = createContext<AuthContextType>({} as AuthContextType)
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null)
   const [loading, setLoading] = useState(true)
+  const [profileNeedsCompletion, setProfileNeedsCompletion] = useState(false)
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (u) => {
@@ -23,6 +28,24 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
     return unsubscribe
   }, [])
+
+  useEffect(() => {
+    if (user) {
+      const checkProfile = async () => {
+        try {
+          const snap = await getDoc(doc(db, 'users', user.uid))
+          setProfileNeedsCompletion(!snap.exists())
+        } catch (err) {
+          console.error('Erreur lors de la vérification du profil:', err)
+          // Si on ne peut pas vérifier, mieux vaut demander les infos
+          setProfileNeedsCompletion(true)
+        }
+      }
+      checkProfile()
+    } else {
+      setProfileNeedsCompletion(false)
+    }
+  }, [user])
 
   const signIn = async () => {
     try {
@@ -51,10 +74,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     await signOut(auth)
   }
 
+  const saveProfile = async (data: { firstName: string; lastName: string; age: number }) => {
+    if (!user) return
+    await setDoc(doc(db, 'users', user.uid), data)
+    setProfileNeedsCompletion(false)
+  }
+
   return (
-    <AuthContext.Provider value={{ user, loading, signIn, signOutUser }}>
-      {children}
-    </AuthContext.Provider>
+    <>
+      <AuthContext.Provider value={{ user, loading, signIn, signOutUser, profileNeedsCompletion, saveProfile }}>
+        {children}
+      </AuthContext.Provider>
+      {profileNeedsCompletion && user && <CompleteProfileModal onSave={saveProfile} />}
+    </>
   )
 }
 

--- a/src/components/CompleteProfileModal.tsx
+++ b/src/components/CompleteProfileModal.tsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react'
+
+interface ProfileData {
+  firstName: string
+  lastName: string
+  age: number
+}
+
+interface Props {
+  onSave: (data: ProfileData) => void
+}
+
+const CompleteProfileModal: React.FC<Props> = ({ onSave }) => {
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [age, setAge] = useState('')
+
+  const handleSubmit = () => {
+    const ageNum = parseInt(age, 10)
+    if (!firstName || !lastName || isNaN(ageNum)) return
+    onSave({ firstName, lastName, age: ageNum })
+  }
+
+  const handleBackdrop = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      // prevent closing by accident
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+      onClick={handleBackdrop}
+    >
+      <div className="bg-white rounded-3xl max-w-md w-full p-8">
+        <h2 className="text-xl font-bold text-gray-800 mb-4">Complétez votre profil</h2>
+        <div className="space-y-4">
+          <input
+            className="w-full border border-gray-200 rounded-lg p-2"
+            placeholder="Prénom"
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+          />
+          <input
+            className="w-full border border-gray-200 rounded-lg p-2"
+            placeholder="Nom"
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+          />
+          <input
+            className="w-full border border-gray-200 rounded-lg p-2"
+            placeholder="Âge"
+            type="number"
+            value={age}
+            onChange={(e) => setAge(e.target.value)}
+          />
+          <button
+            onClick={handleSubmit}
+            className="w-full magic-button bg-tomato-500 hover:bg-tomato-600 text-white py-2 px-4 rounded-xl"
+          >
+            Enregistrer
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CompleteProfileModal

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app'
 import { getAuth, GoogleAuthProvider } from 'firebase/auth'
+import { getFirestore } from 'firebase/firestore'
 
 const firebaseConfig = {
   apiKey: "AIzaSyBpy_hDQRgiOAagl_B-60X40Un-xXgIqI0",
@@ -14,5 +15,6 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig)
 const auth = getAuth(app)
 const provider = new GoogleAuthProvider()
+const db = getFirestore(app)
 
-export { auth, provider }
+export { auth, provider, db }


### PR DESCRIPTION
## Summary
- initialize Firestore in `firebase.ts`
- add a modal for collecting profile info
- manage profile completion in `AuthContext`
- show modal even if Firestore check fails

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845b2ba20ec83269a8254008501b3b4